### PR TITLE
Fix userInteractionEnabled for macOS

### DIFF
--- a/PKHUD/Window.swift
+++ b/PKHUD/Window.swift
@@ -57,6 +57,10 @@ internal class ContainerView: View {
         frameView.center = center
         backgroundView.frame = bounds
     }
+    override func mouseDown(with event: NSEvent) {
+        guard !self.userInteractionEnabled else { return }
+        super.mouseDown(with: event) // Lets the touch go through
+    }
     #endif
 
     internal func showFrameView() {


### PR DESCRIPTION
All the clicks have been passing through on the macOS version of PKHUD, regardless of the `userInteractionEnabled` value. This simple patch fixes it.